### PR TITLE
Reject websocket path on /api/

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -34,9 +34,13 @@ http {
 
 	    server_name localhost;
 
+	    location ~ ^/api/cockpit-(8080|9090)/cockpit/socket {
+		return 418 'not a teapot';
+	    }
+
 	    location ~ ^/(wss|api)/cockpit-(8080|9090)/ {
 		auth_basic "Basic Auth required";
-		auth_basic_user_file /etc/nginx/.htpasswd; 
+		auth_basic_user_file /etc/nginx/.htpasswd;
 
 		# Required to proxy the connection to Cockpit
 		proxy_pass http://host.containers.internal:9999;


### PR DESCRIPTION
This is what the real infrastructure does, and it will help us to
develop a solution for this aspect.