### PR TITLE
Don't pass on Authorization: header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -42,6 +42,9 @@ http {
 		auth_basic "Basic Auth required";
 		auth_basic_user_file /etc/nginx/.htpasswd;
 
+		# Don't pass on proxy auth
+		proxy_set_header Authorization "";
+
 		# Required to proxy the connection to Cockpit
 		proxy_pass http://host.containers.internal:9999;
 		proxy_set_header Host $host;


### PR DESCRIPTION
This is being used to auth the browser against the (3scale/console.dot)
proxy, not against cockpit on the managed server. 3scale drops that
header, do the same here.