### PR TITLE
Hook up 3scale to webconsoleapp

### DIFF
--- a/3scale/nginx.conf
+++ b/3scale/nginx.conf
@@ -20,13 +20,10 @@ http {
     access_log  /var/log/nginx/access.log  main;
 
     sendfile        on;
-    #tcp_nopush     on;
 
     keepalive_timeout  65;
 
-    #gzip  on;
 	server {
-	    listen   80;
 	    listen   443 ssl;
 	    ssl_certificate     /etc/nginx/certs/service-chain.pem;
             ssl_certificate_key /etc/nginx/certs/service-key.pem;
@@ -61,8 +58,12 @@ http {
 		gzip off;
 	    }
 
+	    location /api/webconsole/v1/sessions/new {
+		proxy_pass http://webconsoleapp-front-end:80;
+	    }
+
 	    location / {
-		    return 418 'not a teapot';
+		    return 418 'no route found in 3scale \r\n';
 	    }
       }
 }

--- a/appservice/multiplexer.py
+++ b/appservice/multiplexer.py
@@ -44,12 +44,12 @@ http {{
 
         {routes}
 
-        location /register {{
+        location /api/webconsole/v1/sessions/new {{
             proxy_pass http://localhost:8081;
         }}
 
         location / {{
-            return 404 'not a teapot';
+            return 404 'no route found in multiplexer \r\n';
         }}
       }}
 }}
@@ -95,7 +95,7 @@ class ProxyHTTPRequestHandler(BaseHTTPRequestHandler):
     # protocol_version = 'HTTP/1.0'
 
     def do_GET(self):
-        if self.path == "/register":
+        if self.path == "/api/webconsole/v1/sessions/new":
             sessionid = str(uuid.uuid4())
             name = f'session-{sessionid}'
             connection = http.client.HTTPConnection('localhost')

--- a/webconsoledot-local.yaml
+++ b/webconsoledot-local.yaml
@@ -25,6 +25,12 @@ spec:
     - name: redis
       image: docker.io/redis:latest
 
+    - name: 3scale
+      image: localhost/3scale:latest
+      ports:
+        - containerPort: 443
+          hostPort: 8443
+
   volumes:
     - name: podman-socket
       hostPath:
@@ -33,21 +39,3 @@ spec:
     - name: multiplexer.py
       hostPath:
         path: ./appservice/multiplexer.py
-
----
-
-apiVersion: v1
-kind: Pod
-
-metadata:
-  name: 3scale
-  labels:
-    app: 3scale
-
-spec:
-  containers:
-    - name: nginx
-      image: localhost/3scale:latest
-      ports:
-        - containerPort: 443
-          hostPort: 8443


### PR DESCRIPTION
Two pods in the same network don't seem to share the same DNS resolving so switch to one pod. Wire up the new register path and route it to the webconsoleapp.