### PR TITLE
wire up actual cockpit-ws

### DIFF
--- a/3scale/nginx.conf
+++ b/3scale/nginx.conf
@@ -6,64 +6,63 @@ pid        /var/run/nginx.pid;
 
 
 events {
-    worker_connections  1024;
+    worker_connections 1024;
 }
 
 http {
-    include       /etc/nginx/mime.types;
-    default_type  application/octet-stream;
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+        '$status $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log /var/log/nginx/access.log main;
 
-    sendfile        on;
+    sendfile on;
 
-    keepalive_timeout  65;
+    keepalive_timeout 65;
 
-	server {
-	    listen   443 ssl;
-	    ssl_certificate     /etc/nginx/certs/service-chain.pem;
-            ssl_certificate_key /etc/nginx/certs/service-key.pem;
+    server {
+        listen 443 ssl;
+        ssl_certificate     /etc/nginx/certs/service-chain.pem;
+        ssl_certificate_key /etc/nginx/certs/service-key.pem;
+        server_name localhost;
 
-	    server_name localhost;
+        # Prevent websocket access on /api
+        location ~ ^/api/.*/cockpit/socket {
+            return 418 'websocket cannot be routed via /api';
+        }
 
-            # Prevent websocket access on /api
-	    location ~ ^/api/.*/cockpit/socket {
-               return 418 'websocket cannot be routed via /api';
-	    }
+        location ~ ^/(wss|api)/cockpit-(8080|9090)/ {
+            auth_basic "Basic Auth required";
+            auth_basic_user_file /etc/nginx/.htpasswd;
 
-	    location ~ ^/(wss|api)/cockpit-(8080|9090)/ {
-		auth_basic "Basic Auth required";
-		auth_basic_user_file /etc/nginx/.htpasswd;
+            # Don't pass on proxy auth
+            proxy_set_header Authorization "";
 
-		# Don't pass on proxy auth
-		proxy_set_header Authorization "";
+            # Required to proxy the connection to Cockpit
+            proxy_pass http://host.containers.internal:9999;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
 
-		# Required to proxy the connection to Cockpit
-		proxy_pass http://host.containers.internal:9999;
-		proxy_set_header Host $host;
-		proxy_set_header X-Forwarded-Proto $scheme;
+            # Required for web sockets to function
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
 
-		# Required for web sockets to function
-		proxy_http_version 1.1;
-		proxy_buffering off;
-		proxy_set_header Upgrade $http_upgrade;
-		proxy_set_header Connection "upgrade";
+            # Pass ETag header from Cockpit to clients.
+            # See: https://github.com/cockpit-project/cockpit/issues/5239
+            gzip off;
+        }
 
-		# Pass ETag header from Cockpit to clients.
-		# See: https://github.com/cockpit-project/cockpit/issues/5239
-		gzip off;
-	    }
+        location /api/webconsole/v1/sessions/new {
+            proxy_pass http://webconsoleapp-front-end:80;
+        }
 
-	    location /api/webconsole/v1/sessions/new {
-		proxy_pass http://webconsoleapp-front-end:80;
-	    }
-
-	    location / {
-		    return 418 'no route found in 3scale \r\n';
-	    }
-      }
+        location / {
+            return 418 'no route found in 3scale \r\n';
+        }
+    }
 }

--- a/3scale/nginx.conf
+++ b/3scale/nginx.conf
@@ -34,15 +34,14 @@ http {
             return 418 'websocket cannot be routed via /api';
         }
 
-        location ~ ^/(wss|api)/cockpit-(8080|9090)/ {
+        location ~ ^/wss/webconsole {
             auth_basic "Basic Auth required";
             auth_basic_user_file /etc/nginx/.htpasswd;
-
             # Don't pass on proxy auth
             proxy_set_header Authorization "";
 
+            proxy_pass http://webconsoleapp-front-end;
             # Required to proxy the connection to Cockpit
-            proxy_pass http://host.containers.internal:9999;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-Proto $scheme;
 
@@ -57,8 +56,13 @@ http {
             gzip off;
         }
 
-        location /api/webconsole/v1/sessions/new {
-            proxy_pass http://webconsoleapp-front-end:80;
+        location /api/webconsole {
+            auth_basic "Basic Auth required";
+            auth_basic_user_file /etc/nginx/.htpasswd;
+            # Don't pass on proxy auth
+            proxy_set_header Authorization "";
+
+            proxy_pass http://webconsoleapp-front-end;
         }
 
         location / {

--- a/3scale/nginx.conf
+++ b/3scale/nginx.conf
@@ -28,11 +28,11 @@ http {
 	    ssl_certificate     /etc/nginx/certs/service-chain.pem;
             ssl_certificate_key /etc/nginx/certs/service-key.pem;
 
-
 	    server_name localhost;
 
-	    location ~ ^/api/cockpit-(8080|9090)/cockpit/socket {
-		return 418 'not a teapot';
+            # Prevent websocket access on /api
+	    location ~ ^/api/.*/cockpit/socket {
+               return 418 'websocket cannot be routed via /api';
 	    }
 
 	    location ~ ^/(wss|api)/cockpit-(8080|9090)/ {


### PR DESCRIPTION
How I tested it: `make run`, then `podman cp` the systemd and shell into /usr/share/cockpit, then run `websocat -b ws://127.0.0.1:8080 cmd:cockpit-bridge` inside of the container -- then you get a cockpit shell for the container itself.

Fixes #6

~Before we land, let's (1) fix the paths to be what we expect, and the impedance mismatch between 3scale and appservice #10; and then re-test it~ done