### PR TITLE
appservice: Fix /new response and error handling

### DIFF
--- a/appservice/multiplexer.py
+++ b/appservice/multiplexer.py
@@ -155,12 +155,15 @@ class ProxyHTTPRequestHandler(BaseHTTPRequestHandler):
         REDIS.set('sessions', dumped_sessions)
         REDIS.publish('sessions', dumped_sessions)
 
-        self.send_response(200)
-        self.end_headers()
-        if response.status != 200:
-            self.wfile.write(content)
+        if response.status >= 200 and response.status < 300:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps({ "id": sessionid }).encode())
         else:
-            self.wfile.write(f"container created {name}\r\n".encode('utf-8'))
+            self.send_response(response.status)
+            self.end_headers()
+            self.wfile.write(f"creating container failed: ".encode())
+            self.wfile.write(content)
 
     def do_GET(self):
         if self.path == "/api/webconsole/v1/sessions/new":


### PR DESCRIPTION
Creating a container successfully responds with code 200. Accept any 2XX 
code.

Forward podman's error code on container creation failure, instead of always
replying with 200.

Return the session ID, the caller needs it. 

Fixes #16 

----

Success case:
```
❱❱❱ make run && sleep 2 && curl -v -u admin:foobar -k https://localhost:8443/api/webconsole/v1/sessions/new
< HTTP/1.1 200 OK
{"id": "f73d50b7-a073-4b68-9bd1-e21525abae8c"}
```
Failure case:
```
< HTTP/1.1 404 Not Found
creating container failed: {"cause":"repository name must be lowercase","message":"repository name must be lowercase","response":500}
```