### PR TITLE
appservice: Replace nginx with Starlette reverse proxy, add session status API

### DIFF
--- a/3scale/nginx.conf
+++ b/3scale/nginx.conf
@@ -55,7 +55,7 @@ http {
             # proxy_set_header Connection $http_connection;
             # .. but it doesn't: it always adds this header even for plain HTTP requests
             # https://issues.redhat.com/browse/RHCLOUD-21326
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Connection "Upgrade";
 
             # Pass ETag header from Cockpit to clients.
             # See: https://github.com/cockpit-project/cockpit/issues/5239

--- a/appservice/Containerfile
+++ b/appservice/Containerfile
@@ -1,12 +1,9 @@
 FROM debian:bookworm
 
 RUN apt-get update && \
-    apt-get install -y python3 python3-redis nginx curl inetutils-ping procps && \
+    apt-get install -y python3 python3-redis python3-aiohttp curl inetutils-ping procps && \
     apt-get clean && \
     rm /var/lib/apt/lists/*dists*
-
-# allow unprivileged container user to run nginx and change configuration
-RUN chmod -R a+rw /etc/nginx/ /var/lib/nginx/ /var/log/nginx/ /run
 
 COPY *.py /usr/local/bin/
 

--- a/appservice/Containerfile
+++ b/appservice/Containerfile
@@ -2,7 +2,7 @@ FROM docker.io/redhat/ubi9-minimal
 
 # iputils and procps-ng are just for debugging; drop for production
 RUN microdnf install -y python3-pip iputils procps-ng && microdnf clean all
-RUN pip3 install aiohttp redis
+RUN pip3 install redis starlette httpx websockets uvicorn
 
 COPY *.py /usr/local/bin/
 

--- a/appservice/Containerfile
+++ b/appservice/Containerfile
@@ -1,9 +1,8 @@
-FROM debian:bookworm
+FROM docker.io/redhat/ubi9-minimal
 
-RUN apt-get update && \
-    apt-get install -y python3 python3-redis python3-aiohttp curl inetutils-ping procps && \
-    apt-get clean && \
-    rm /var/lib/apt/lists/*dists*
+# iputils and procps-ng are just for debugging; drop for production
+RUN microdnf install -y python3-pip iputils procps-ng && microdnf clean all
+RUN pip3 install aiohttp redis
 
 COPY *.py /usr/local/bin/
 

--- a/appservice/multiplexer.py
+++ b/appservice/multiplexer.py
@@ -5,183 +5,221 @@ import logging
 import os
 import uuid
 
-import aiohttp
-from aiohttp import web
+import httpx
 import redis.asyncio as redis
+import uvicorn
+import websockets
+
+from starlette.applications import Starlette
+from starlette.background import BackgroundTask
+from starlette.concurrency import run_until_first_complete
+from starlette.responses import PlainTextResponse, JSONResponse, StreamingResponse
+from starlette.websockets import WebSocket
 
 import config
 
-logger = logging.getLogger('multiplexer')
-
 API_URL = os.environ['API_URL']
 SESSION_INSTANCE_DOMAIN = os.getenv('SESSION_INSTANCE_DOMAIN', '')
-
 PODMAN_SOCKET = '/run/podman/podman.sock'
+
 # states: wait_target or running
 SESSIONS = {}
+
 REDIS = redis.Redis(host=os.environ['REDIS_SERVICE_HOST'], port=int(os.environ.get('REDIS_SERVICE_PORT', '6379')))
+logger = logging.getLogger('multiplexer')
+app = Starlette()
 
 
-async def _wsforward(ws_from, ws_to):
-    async for msg in ws_from:
-        if msg.type == aiohttp.WSMsgType.TEXT:
-            await ws_to.send_str(msg.data)
-        elif msg.type == aiohttp.WSMsgType.BINARY:
-            await ws_to.send_bytes(msg.data)
-        elif ws_to.closed:
-            await ws_to.close(code=ws_to.close_code, message=msg.extra)
+@app.route(f'{config.ROUTE_API}/ping')
+async def handle_ping(request):
+    return PlainTextResponse('pong')
+
+
+async def new_session_podman(sessionid):
+    name = f'session-{sessionid}'
+    body = {
+        'image': 'quay.io/rhn_engineering_mpitt/ws',
+        'name': name,
+        # for local debugging
+        # 'command': ['sleep', 'infinity'],
+        # XXX: http://localhost:8080 origin is for directly connecting to appservice, without 3scale
+        'command': ['sh', '-exc',
+                    f"mkdir -p /tmp/conf/cockpit; "
+                    f"printf '[Webservice]\nUrlRoot={config.ROUTE_WSS}/sessions/{sessionid}/web\\n"
+                    f"Origins = {API_URL} http://localhost:8080\\n'"
+                    "> /tmp/conf/cockpit/cockpit.conf;"
+                    "export XDG_CONFIG_DIRS=/tmp/conf;"
+                    "exec /usr/libexec/cockpit-ws --for-tls-proxy --local-session=socat-session.sh"],
+        'netns': {'nsmode': 'bridge'},
+        # deprecated; use this with podman ≥ 4: 'Networks': {'consoledot': {}},
+        'cni_networks': ['consoledot'],
+        'user': 'cockpit-wsinstance',
+    }
+
+    async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=PODMAN_SOCKET)) as podman:
+        response = await podman.post('http://none/v1.12/libpod/containers/create', data=json.dumps(body).encode())
+        status = response.status_code
+        content = response.text
+
+        if status >= 200 and status < 300:
+            logger.debug('/new: creating container succeeded with %i: %s; starting container', status, content)
+            response = await podman.post(f'http://none/v1.12/libpod/containers/{name}/start')
+            status = response.status_code
+            content = response.text
+
+    return status, content
+
+
+@app.route(f'{config.ROUTE_API}/sessions/new')
+async def handle_session_new(request):
+    sessionid = str(uuid.uuid4())
+    assert sessionid not in SESSIONS
+
+    if os.path.exists(PODMAN_SOCKET):
+        pod_status, content = await new_session_podman(sessionid)
+    else:
+        # TODO: support k8s API
+        raise NotImplementedError('cannot create sessions other than podman')
+
+    if pod_status >= 200 and pod_status < 300:
+        response = JSONResponse({'id': sessionid})
+        await update_session(sessionid, 'wait_target')
+    else:
+        response = PlainTextResponse(f'creating session container failed: {content}', status_code=pod_status)
+
+    return response
+
+
+@app.route(f'{config.ROUTE_API}/sessions/{{sessionid}}/status')
+async def handle_session_status(request):
+    sessionid = request.path_params['sessionid']
+    try:
+        return PlainTextResponse(SESSIONS[sessionid])
+    except KeyError:
+        return PlainTextResponse('unknown session ID', status_code=404)
+
+
+async def ws_up2down(recv_ws: WebSocket, send_ws: websockets.WebSocketClientProtocol):
+    while True:
+        msg = await recv_ws.receive()
+        if msg['type'] == 'websocket.receive':
+            data = msg.get('text') or msg.get('bytes')
+            await send_ws.send(data)
+        elif msg['type'] == 'websocket.disconnect':
+            break
+
+
+async def ws_down2up(recv_ws: websockets.WebSocketClientProtocol, send_ws: WebSocket):
+    while True:
+        data = await recv_ws.recv()
+        if isinstance(data, str):
+            await send_ws.send_text(data)
         else:
-            raise ValueError(f'unexpected ws message type: {msg.type}')
+            await send_ws.send_bytes(data)
 
 
-class Handlers:
-    def __init__(self):
-        self.ws_client_sessions = {}
+async def websocket_forward(upstream_ws: WebSocket, target_url: str):
+    await upstream_ws.accept()
+    headers = []
+    origin = None
+    for k, v in upstream_ws.scope['headers']:
+        if k == b'origin':
+            origin = v.decode()
+        # XXX: do we need to forward any other headers?
 
-    async def __aenter__(self):
-        return self
+    logging.debug('websocket_forward %s → %s; origin %s', upstream_ws.url.path, target_url, origin)
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        for s in self.ws_client_sessions.values():
-            if not s.closed:
-                await s.close()
+    downstream_ws = await websockets.connect(
+        target_url,
+        subprotocols=upstream_ws.scope['subprotocols'],
+        origin=origin,
+        extra_headers=headers,
+    )
+    await run_until_first_complete(
+        (ws_up2down, {'recv_ws': upstream_ws, 'send_ws': downstream_ws}),
+        (ws_down2up, {'recv_ws': downstream_ws, 'send_ws': upstream_ws}),
+    )
+    await downstream_ws.close()
 
-    def handle_ping(self, request):
-        return web.Response(text='pong')
 
-    async def new_session_podman(self, sessionid):
-        name = f'session-{sessionid}'
-        body = {
-                'image': 'quay.io/rhn_engineering_mpitt/ws',
-                'name': name,
-                # for local debugging
-                # 'command': ['sleep', 'infinity'],
-                # XXX: http://localhost:8080 origin is for directly connecting to appservice, without 3scale
-                'command': ['sh', '-exc',
-                            f"mkdir -p /tmp/conf/cockpit; "
-                            f"printf '[Webservice]\nUrlRoot={config.ROUTE_WSS}/sessions/{sessionid}/web\\n"
-                            f"Origins = {API_URL} http://localhost:8080\\n'"
-                            "> /tmp/conf/cockpit/cockpit.conf;"
-                            "export XDG_CONFIG_DIRS=/tmp/conf;"
-                            "exec /usr/libexec/cockpit-ws --for-tls-proxy --local-session=socat-session.sh"],
-                'netns': {'nsmode': 'bridge'},
-                # deprecated; use this with podman ≥ 4: 'Networks': {'consoledot': {}},
-                'cni_networks': ['consoledot'],
-                'user': 'cockpit-wsinstance',
-        }
+@app.websocket_route(f'{config.ROUTE_WSS}/sessions/{{sessionid}}/ws')
+async def handle_session_id_bridge(ws: WebSocket):
+    '''reverse-proxy bridge websocket to session pod'''
 
-        async with aiohttp.ClientSession(connector=aiohttp.UnixConnector(PODMAN_SOCKET)) as podman:
-            async with podman.post('http://none/v1.12/libpod/containers/create',
-                                   data=json.dumps(body).encode()) as response:
-                status = response.status
-                content = await response.text()
+    sessionid = ws.path_params['sessionid']
+    if sessionid not in SESSIONS:
+        await ws.close(reason='unknown session ID', code=404)
+        return
 
-            if status >= 200 and status < 300:
-                logger.debug('/new: creating container succeeded with %i: %s; starting container', status, content)
-                async with podman.post(f'http://none/v1.12/libpod/containers/{name}/start') as response:
-                    status = response.status
-                    content = await response.text()
+    if SESSIONS[sessionid] == 'wait_target':
+        asyncio.create_task(update_session(sessionid, 'running'))
+    await websocket_forward(ws, f'ws://session-{sessionid}{SESSION_INSTANCE_DOMAIN}:8080{ws.url.path}')
 
-        return status, content
 
-    async def handle_session_new(self, request):
-        sessionid = str(uuid.uuid4())
-        assert sessionid not in SESSIONS
+@app.websocket_route(f'{config.ROUTE_WSS}/sessions/{{sessionid}}/web/{{path:path}}')
+async def handle_session_id_ws(ws: WebSocket):
+    '''reverse-proxy cockpit websocket to session pod'''
 
-        if os.path.exists(PODMAN_SOCKET):
-            pod_status, content = await self.new_session_podman(sessionid)
-        else:
-            # TODO: support k8s API
-            raise NotImplementedError('cannot create sessions other than podman')
+    sessionid = ws.path_params['sessionid']
+    if sessionid not in SESSIONS:
+        await ws.close(reason='unknown session ID', code=404)
+        return
+    await websocket_forward(ws, f'ws://session-{sessionid}{SESSION_INSTANCE_DOMAIN}:9090{ws.url.path}')
 
-        if pod_status >= 200 and pod_status < 300:
-            response = web.json_response({'id': sessionid})
-            await update_session(sessionid, 'wait_target')
-        else:
-            response = web.Response(status=pod_status, text=f'creating session container failed: {content}')
 
-        return response
+@app.route(f'{config.ROUTE_WSS}/sessions/{{sessionid}}/web/{{path:path}}', methods=['GET', 'HEAD'])
+async def handle_session_id_http(upstream_req):
+    '''reverse-proxy cockpit HTTP to session pod'''
 
-    async def handle_session_status(self, request):
-        sessionid = request.match_info['sessionid']
+    sessionid = upstream_req.path_params['sessionid']
+    if sessionid not in SESSIONS:
+        return PlainTextResponse('unknown session ID', status_code=404)
+
+    target_url = f'http://session-{sessionid}{SESSION_INSTANCE_DOMAIN}:9090{upstream_req.url.path}'
+
+    client = httpx.AsyncClient()
+    downstream_req = client.build_request(
+        method=upstream_req.method,
+        url=target_url,
+        headers=upstream_req.headers.items(),
+        params=upstream_req.query_params,
+        cookies=upstream_req.cookies,
+    )
+    downstream_response = await client.send(downstream_req, stream=True)
+    return StreamingResponse(
+        downstream_response.aiter_raw(),
+        headers=dict(downstream_response.headers),
+        background=BackgroundTask(downstream_response.aclose)
+    )
+
+
+async def watch_redis(channel):
+    global SESSIONS
+    while True:
         try:
-            return web.Response(text=SESSIONS[sessionid])
-        except KeyError:
-            return web.HTTPNotFound(text='unknown session ID')
+            async with async_timeout.timeout(1):
+                message = await channel.get_message(ignore_subscribe_messages=True)
+                if message is not None and message['channel'] == b'sessions':
+                    logger.debug('got redis sessions update: %s', message['data'])
+                    try:
+                        SESSIONS = json.loads(message['data'].decode())
+                    except json.decoder.JSONDecodeError as e:
+                        logger.warning('invalid JSON, starting without sessions: %s', e)
+                        SESSIONS = {}
 
-    async def handle_session_id(self, upstream_req):
-        sessionid = upstream_req.match_info['sessionid']
-        if sessionid not in SESSIONS:
-            return web.HTTPNotFound(text='unknown session ID')
-
-        path = upstream_req.match_info['path']
-        if path.startswith('web/'):
-            target_url = f'http://session-{sessionid}{SESSION_INSTANCE_DOMAIN}:9090{upstream_req.path_qs}'
-        elif path == 'ws':
-            target_url = f'http://session-{sessionid}{SESSION_INSTANCE_DOMAIN}:8080{upstream_req.path_qs}'
-            if SESSIONS[sessionid] == 'wait_target':
-                await update_session(sessionid, 'running')
-        else:
-            return web.HTTPNotFound(text=f'invalid session path prefix: {path}')
-
-        # reverse-proxy the request to session pod
-
-        # lazily initialize per-session HTTP client
-        if sessionid not in self.ws_client_sessions or self.ws_client_sessions[sessionid].closed:
-            cs = aiohttp.ClientSession(auto_decompress=False, cookie_jar=aiohttp.DummyCookieJar())
-            self.ws_client_sessions[sessionid] = cs
-        else:
-            cs = self.ws_client_sessions[sessionid]
-
-        if (upstream_req.method == 'GET'
-                and 'upgrade' in upstream_req.headers.get('Connection', '').lower()
-                and upstream_req.headers.get('Upgrade') == 'websocket'):
-            # it's a websocket upgrade request
-            async with cs.ws_connect(target_url, headers=dict(upstream_req.headers)) as downstream_ws_client:
-                upstream_ws_response = web.WebSocketResponse()
-                upstream_ws_response._headers = downstream_ws_client._response._headers.copy()
-                await upstream_ws_response.prepare(upstream_req)
-                await asyncio.gather(
-                    _wsforward(downstream_ws_client, upstream_ws_response),
-                    _wsforward(upstream_ws_response, downstream_ws_client))
-                return upstream_ws_response
-
-        else:
-            # it's an plain HTTP request
-            async with cs.request(
-                upstream_req.method,
-                target_url,
-                headers=upstream_req.headers,
-                data=upstream_req.content,
-                allow_redirects=False,
-            ) as downstream_response:
-                h = downstream_response.headers.copy()
-
-                if h.get('Transfer-Encoding') == 'chunked':
-                    upstream_resp = web.StreamResponse(
-                        status=downstream_response.status,
-                        reason=downstream_response.reason,
-                        headers=h,
-                    )
-                    upstream_resp.enable_chunked_encoding()
-                    await upstream_resp.prepare(upstream_req)
-                    async for data, _ in downstream_response.content.iter_chunks():
-                        await upstream_resp.write(data)
-                    await upstream_resp.write_eof()
-                    return upstream_resp
-                else:
-                    upstream_resp = web.Response(
-                        status=downstream_response.status,
-                        reason=downstream_response.reason,
-                        headers=h,
-                        body=await downstream_response.content.read(),
-                    )
-
-                return upstream_resp
+                await asyncio.sleep(0.01)
+        except asyncio.TimeoutError:
+            pass
 
 
+@app.on_event('startup')
 async def init_sessions():
     global SESSIONS
+
+    pubsub = REDIS.pubsub()
+    await pubsub.subscribe('sessions')
+    asyncio.create_task(watch_redis(pubsub))
+
     sessions = await REDIS.get('sessions')
     if sessions is None:
         SESSIONS = {}
@@ -202,45 +240,6 @@ async def update_session(session_id, status):
     await REDIS.publish('sessions', dumped_sessions)
 
 
-async def watch_redis(channel):
-    global SESSIONS
-    while True:
-        try:
-            async with async_timeout.timeout(1):
-                message = await channel.get_message(ignore_subscribe_messages=True)
-                if message is not None and message['channel'] == b'sessions':
-                    logger.debug("got redis sessions update: %s", message['data'])
-                    try:
-                        SESSIONS = json.loads(message['data'].decode())
-                    except json.decoder.JSONDecodeError as e:
-                        logger.warning("invalid JSON, starting without sessions: %s", e)
-                        SESSIONS = {}
-
-                await asyncio.sleep(0.01)
-        except asyncio.TimeoutError:
-            pass
-
-
-async def main():
-    async with Handlers() as handlers:
-        pubsub = REDIS.pubsub()
-        await pubsub.subscribe('sessions')
-        asyncio.create_task(watch_redis(pubsub))
-        await init_sessions()
-
-        app = web.Application()
-        app.router.add_route('GET', f'{config.ROUTE_API}/ping', handlers.handle_ping)
-        app.router.add_route('GET', f'{config.ROUTE_API}/sessions/new', handlers.handle_session_new)
-        app.router.add_route('GET', f'{config.ROUTE_API}/sessions/{{sessionid}}/status', handlers.handle_session_status)
-        app.router.add_route('*', f'{config.ROUTE_WSS}/sessions/{{sessionid}}/{{path:.*}}', handlers.handle_session_id)
-
-        runner = web.AppRunner(app, auto_decompress=False)
-        await runner.setup()
-        await web.TCPSite(runner, port=8080).start()
-        while True:
-            await asyncio.sleep(60)
-
-
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    asyncio.run(main())
+    uvicorn.run(app, host='0.0.0.0', port=8080)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -99,7 +99,7 @@ class IntegrationTest(unittest.TestCase):
     def newSession(self):
         response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/new')
         self.assertEqual(response.status, 200)
-        self.assertEqual(response.getheader('Content-Type'), 'application/json; charset=utf-8')
+        self.assertEqual(response.getheader('Content-Type'), 'application/json')
         sessionid = json.load(response)['id']
         self.assertIsInstance(sessionid, str)
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -103,6 +103,11 @@ class IntegrationTest(unittest.TestCase):
         sessionid = json.load(response)['id']
         self.assertIsInstance(sessionid, str)
 
+        # inital status
+        response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/{sessionid}/status')
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.read(), b'wait_target')
+
         # API URL is on the container host's localhost; translate for the container DNS
         websocket_url = self.api_url.replace('localhost', 'host.containers.internal').replace('https:', 'wss:')
         podman = ['podman', 'run', '-d', '--pod', 'webconsoleapp',
@@ -112,6 +117,17 @@ class IntegrationTest(unittest.TestCase):
                'cmd:cockpit-bridge']
 
         subprocess.check_call(podman + cmd)
+
+        # successful bridge connection updates status
+        for retry in range(10):
+            response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/{sessionid}/status')
+            self.assertEqual(response.status, 200)
+            status = response.read()
+            if status == b'running':
+                break
+            time.sleep(0.5)
+        else:
+            self.fail(f'session status was not updated to running, still at {status}')
 
         return sessionid
 
@@ -141,6 +157,11 @@ class IntegrationTest(unittest.TestCase):
         self.checkSession(s2)
         # first session still works
         self.checkSession(s1)
+
+        # unknown session ID
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            self.request(f'{self.api_url}{config.ROUTE_API}/sessions/123unknown/status')
+        self.assertEqual(cm.exception.code, 404)
 
         # crash container for s2; use --time 0 once we have podman 4.0 everywhere
         subprocess.check_call(['podman', 'rm', '--force', f'session-{s2}'])

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -99,6 +99,7 @@ class IntegrationTest(unittest.TestCase):
     def newSession(self):
         response = self.request(f'{self.api_url}{config.ROUTE_API}/sessions/new')
         self.assertEqual(response.status, 200)
+        self.assertEqual(response.getheader('Content-Type'), 'application/json; charset=utf-8')
         sessionid = json.load(response)['id']
         self.assertIsInstance(sessionid, str)
 
@@ -138,6 +139,21 @@ class IntegrationTest(unittest.TestCase):
         # can create more than one session
         s2 = self.newSession()
         self.checkSession(s2)
+        # first session still works
+        self.checkSession(s1)
+
+        # crash container for s2; use --time 0 once we have podman 4.0 everywhere
+        subprocess.check_call(['podman', 'rm', '--force', f'session-{s2}'])
+        # first session still works
+        self.checkSession(s1)
+        # second session is broken
+        request = self.get_auth_request(f'{self.api_url}{config.ROUTE_WSS}/sessions/{s2}/web/')
+        with self.assertRaises(OSError):
+            urllib.request.urlopen(request, context=self.ssl_3scale, timeout=1)
+
+        # can create a new session
+        s3 = self.newSession()
+        self.checkSession(s3)
         # first session still works
         self.checkSession(s1)
 


### PR DESCRIPTION
nginx does not get along well with unavailable proxy_pass targets -- as soon as one session pod unexpectedly goes away (crashes, idle timeouts, networking flakes), it errors out and no session routes can be resolved any more. There are workarounds [1], but I can't get them to work properly. Also, nginx does not allow us to hook into (dis)connection events to implement the session status API (see issue #28).

So it's finally time to grow to something more flexible.

Fixes #36
Fixes #28

[1] https://sandro-keil.de/blog/let-nginx-start-if-upstream-host-is-unavailable-or-down/

------
 - [x] test/fix issue #36 to demonstrate why this is useful
 - [x] Move to UBI image
 - [x] Bring back [redis](https://redis-py.readthedocs.io/en/stable/examples/asyncio_examples.html)
 - [x] fix/work around "aiohttp.client_exceptions.ClientPayloadError: Response payload is not completed", see https://github.com/aio-libs/aiohttp/issues/4581 → no workaround found, moved to starlette
 - [x] work around [broken 3scale Connection: header](https://issues.redhat.com/browse/RHCLOUD-21326)

@tiran FYI