### PR TITLE
Revert "3scale: Don't upgrade all connections"

### DIFF
--- a/3scale/nginx.conf
+++ b/3scale/nginx.conf
@@ -51,7 +51,11 @@ http {
             proxy_http_version 1.1;
             proxy_buffering off;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $http_connection;
+            # consoledot/3scale should really do this:
+            # proxy_set_header Connection $http_connection;
+            # .. but it doesn't: it always adds this header even for plain HTTP requests
+            # https://issues.redhat.com/browse/RHCLOUD-21326
+            proxy_set_header Connection "upgrade";
 
             # Pass ETag header from Cockpit to clients.
             # See: https://github.com/cockpit-project/cockpit/issues/5239


### PR DESCRIPTION
This was an error -- 3scale actually *does* add a `Connection: Upgrade` header on each /wss request. Our multiplexer needs to deal with that somehow.

This reverts commit d694b263cb92175ff876631be75b4b68d1a29fd3.

----

Sorry for the screw-up! Headers with /api:
```
GET /api/webconsole/v1/sessions/f5a65982-5a23-412f-a73b-d8f3da160b61/web/ HTTP/1.1
X-Real-IP: 127.0.0.1
Host: webconsole.cockpit-dev.svc.cluster.local:8080
X-3scale-proxy-secret-token: ...
fakamaienv: test
accept: */*
user-agent: curl/7.85.0
x-forwarded-host: test.cloud.redhat.com
x-forwarded-port: 443
x-forwarded-proto: https
forwarded: for=66.187.232.127;host=api-gateway-dev-3scale-dev.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com;proto=https
x-rh-insights-request-id: 74330a93e26c4787922570693f996bc8
x-rh-identity:
```

vs. on /wss:

```diff
+Connection: Upgrade
+websocket_conn: true
```