### PR TITLE
appservice: Run sessions in our own appservice container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ server/cockpit-bridge-websocket-connector.pyz: server/cockpit-bridge-websocket-c
 containers:
 	podman build -t $(CONTAINER_NAME) appservice
 	podman build -t $(SERVER_CONTAINER_NAME) server
-	podman pull quay.io/rhn_engineering_mpitt/ws
 
 run: 3scale/certs/service-chain.pem
 	[ -z "$$(podman network ls --quiet --filter 'name=$(NETWORK)')" ] || $(MAKE) clean

--- a/appservice/Containerfile
+++ b/appservice/Containerfile
@@ -2,7 +2,16 @@ FROM docker.io/redhat/ubi9-minimal
 
 # iputils and procps-ng are just for debugging; drop for production
 RUN microdnf install -y python3-pip iputils procps-ng && microdnf clean all
+# cockpit is not available in UBI, install from CentOS 9 stream; c-bridge is just for debugging, drop for production
+RUN printf '[c9s]\nname = C9S\nbaseurl = http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os\ngpgcheck = 0\n' > /etc/yum.repos.d/c9s.repo
+RUN microdnf install --enablerepo=c9s --setopt=install_weak_deps=0 -y cockpit-ws cockpit-bridge && microdnf clean all
+
 RUN pip3 install redis starlette httpx websockets uvicorn
+
+RUN mkdir -p /usr/local/bin/ && \
+    curl -L -o /usr/local/bin/websocat https://github.com/vi/websocat/releases/download/v1.10.0/websocat.x86_64-unknown-linux-musl && \
+    echo 'exec websocat -b -s 0.0.0.0:8080' > /usr/local/bin/socat-session.sh && \
+    chmod a+x /usr/local/bin/websocat /usr/local/bin/socat-session.sh
 
 COPY *.py /usr/local/bin/
 

--- a/appservice/multiplexer.py
+++ b/appservice/multiplexer.py
@@ -40,7 +40,7 @@ async def handle_ping(request):
 async def new_session_podman(sessionid):
     name = f'session-{sessionid}'
     body = {
-        'image': 'quay.io/rhn_engineering_mpitt/ws',
+        'image': 'localhost/webconsoleapp',
         'name': name,
         # for local debugging
         # 'command': ['sleep', 'infinity'],
@@ -55,7 +55,6 @@ async def new_session_podman(sessionid):
         'netns': {'nsmode': 'bridge'},
         # deprecated; use this with podman ≥ 4: 'Networks': {'consoledot': {}},
         'cni_networks': ['consoledot'],
-        'user': 'cockpit-wsinstance',
     }
 
     async with httpx.AsyncClient(transport=httpx.AsyncHTTPTransport(uds=PODMAN_SOCKET)) as podman:


### PR DESCRIPTION
This gives us more control over the container and drops the outdated and PoC/hack quay.io/rhn_engineering_mpitt/ws image. Running just one image on OpenShift is also more efficient.

---

With that we can bury https://github.com/cockpit-project/cockpit/pull/17473 and go back to standard cockpit-ws.